### PR TITLE
DB: add ignore flag functionality to updates

### DIFF
--- a/src/DBQuery.php
+++ b/src/DBQuery.php
@@ -8,7 +8,7 @@ abstract class DBQuery {
 
 	protected $table;
 	protected $db;
-	protected $allowed_operations = ['SELECT', 'UPDATE', 'INSERT', 'INSERT IGNORE', 'UPSERT', 'DELETE'];
+	protected $allowed_operations = ['SELECT', 'UPDATE', 'UPDATE IGNORE', 'INSERT', 'INSERT IGNORE', 'UPSERT', 'DELETE'];
 
 	public function __construct($table, $db = '', array $allowed_ops = []) {
 		$this->table = $table;


### PR DESCRIPTION
Adding the `IGNORE` flag on updates means we can ignore errors from duplicate values into a unique field, etc.

https://dev.mysql.com/doc/refman/5.6/en/update.html