### PR TITLE
dont backtick * when selecting * from a specific table i.e. 't1.*'

### DIFF
--- a/src/SQLQuery.php
+++ b/src/SQLQuery.php
@@ -1306,7 +1306,11 @@ abstract class SQLQuery extends DBQuery {
 	 */
 	public function quoteKeyword($text) {
 		$text = explode('.', $this->escapeKeyword($text));
-		if (count($text) === 2 && $text[1] === '*') return $this->tick . $text[0] . $this->tick . ".*"; // don't backtick '*'
+		// don't backtick '*'
+		$end = end($text);
+		if ($end === '*') {
+			return $this->tick . implode("$this->tick.$this->tick", array_slice($text, 0, count($text) - 1)) . $this->tick . ".$end";
+		}
 		return $this->tick . implode("$this->tick.$this->tick", $text) . $this->tick;
 	}
 

--- a/src/SQLQuery.php
+++ b/src/SQLQuery.php
@@ -1306,6 +1306,7 @@ abstract class SQLQuery extends DBQuery {
 	 */
 	public function quoteKeyword($text) {
 		$text = explode('.', $this->escapeKeyword($text));
+		if (count($text) === 2 && $text[1] === '*') return $this->tick . $text[0] . $this->tick . "." . '*';
 		return $this->tick . implode("$this->tick.$this->tick", $text) . $this->tick;
 	}
 

--- a/src/SQLQuery.php
+++ b/src/SQLQuery.php
@@ -1306,7 +1306,7 @@ abstract class SQLQuery extends DBQuery {
 	 */
 	public function quoteKeyword($text) {
 		$text = explode('.', $this->escapeKeyword($text));
-		if (count($text) === 2 && $text[1] === '*') return $this->tick . $text[0] . $this->tick . "." . '*';
+		if (count($text) === 2 && $text[1] === '*') return $this->tick . $text[0] . $this->tick . ".*"; // don't backtick '*'
 		return $this->tick . implode("$this->tick.$this->tick", $text) . $this->tick;
 	}
 


### PR DESCRIPTION
When trying to select `*` from a specific table, DB backticks the select. 

```
t1.*
```
becomes
``` 
`t1`.`*`
```
This appears to work fine on MySQL 5.7, but not on 5.6.

This change will cause it to instead become 
```
`t1`.*
```